### PR TITLE
Implement language toggle and align buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -256,15 +256,18 @@
      const container = document.getElementById('language-buttons');
      if (!container) return;
      container.innerHTML = '';
-     availableLangs.forEach(lang => {
-       const btn = document.createElement('button');
-       btn.textContent = lang.toUpperCase();
-       btn.addEventListener('click', () => {
-         translationLang = lang;
-         updateTranslation();
-       });
-       container.appendChild(btn);
+
+     const btn = document.createElement('button');
+     btn.id = 'language-toggle';
+     btn.textContent = translationLang.toUpperCase();
+     btn.addEventListener('click', () => {
+       const idx = availableLangs.indexOf(translationLang);
+       const next = (idx + 1) % availableLangs.length;
+       translationLang = availableLangs[next];
+       btn.textContent = translationLang.toUpperCase();
+       updateTranslation();
      });
+     container.appendChild(btn);
   }
 
   function loadExample(animated = false) {

--- a/style.css
+++ b/style.css
@@ -396,6 +396,7 @@ h1 {
   justify-content: center;
   position: relative;
   gap: 0.5rem;
+  padding-left: calc(2rem + 0.5rem);
 }
 
 #reset-score {
@@ -411,7 +412,7 @@ h1 {
   align-items: center;
   justify-content: center;
   position: absolute;
-  left: calc(-2rem - 0.5rem);
+  left: 0;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -442,6 +443,7 @@ h1 {
   display: flex;
   justify-content: center;
   margin: 0.5rem;
+  padding-right: calc(2rem + 0.5rem);
 }
 
 .check-container button {
@@ -461,7 +463,7 @@ h1 {
   align-items: center;
   justify-content: center;
   position: absolute;
-  left: calc(100% + 0.5rem);
+  right: 0;
   top: 50%;
   transform: translateY(-50%);
 }


### PR DESCRIPTION
## Summary
- use one language toggle button that cycles through available languages
- adjust layout so auto delay and reset buttons align with their containers

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_688954d91ee8833098e75a816901f133