### PR TITLE
Improve translation and buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
     <div class="sentence-container" id="sentence"></div>
     <div id="translation" class="translation">
       <span id="translation-text"></span>
-      <span id="language-buttons" class="language-buttons"></span>
+      <span id="language-button" class="language-button"></span>
     </div>
     <div class="clitic-options" id="cliticOptions"></div>
     <div class="buttons">

--- a/script.js
+++ b/script.js
@@ -250,10 +250,20 @@
      const tr = currentExample.translations &&
        currentExample.translations[translationLang];
      el.textContent = tr || currentExample.translation || '';
+     if (currentExample.translations) {
+       let maxLen = 0;
+       availableLangs.forEach(l => {
+         const t = currentExample.translations[l];
+         if (t && t.length > maxLen) maxLen = t.length;
+       });
+       el.style.minWidth = maxLen + 'ch';
+     } else {
+       el.style.minWidth = '';
+     }
   }
 
   function createLanguageButtons() {
-     const container = document.getElementById('language-buttons');
+     const container = document.getElementById('language-button');
      if (!container) return;
      container.innerHTML = '';
 

--- a/style.css
+++ b/style.css
@@ -137,20 +137,24 @@ body {
   margin-bottom: 1rem;
   font-style: italic;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
-.language-buttons {
+.language-button {
   margin-left: 0.5rem;
   font-style: normal;
 }
 
-.language-buttons button {
+.language-button button {
   background: none;
   border: none;
   color: white;
   cursor: pointer;
   padding: 0 0.25rem;
   font-size: 0.9rem;
+  font-weight: bold;
 }
 
 .word-block {
@@ -438,12 +442,11 @@ h1 {
 
 /* Check button container layout */
 .check-container {
-  position: relative;
-  width: fit-content;
   display: flex;
   justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
   margin: 0.5rem;
-  padding-right: calc(2rem + 0.5rem);
 }
 
 .check-container button {
@@ -462,10 +465,6 @@ h1 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  position: absolute;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
 }
 
 #auto-delay-button svg {


### PR DESCRIPTION
## Summary
- rename `language-buttons` container to `language-button`
- keep language button fixed width based on longest translation
- show language button in bold
- center check button area and place auto-delay button beside it

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6889d9473a888330b1409e69566e80a4