### PR TITLE
Fix translation centering with absolute language toggle

### DIFF
--- a/style.css
+++ b/style.css
@@ -137,7 +137,10 @@ body {
   color: white;
   margin-bottom: 1rem;
   font-style: italic;
-  text-align: center;
+  display: flex;
+  justify-content: center;
+  position: relative;
+  padding-right: calc(4ch + 0.5rem);
 }
 
 #translation-text {
@@ -146,7 +149,12 @@ body {
 
 .language-button {
   font-style: normal;
-  margin-left: 0.5rem;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 4ch;
+  margin-left: 0;
 }
 
 .language-button button {


### PR DESCRIPTION
## Summary
- update `.translation` styling so translation text stays centered
- absolutely position `.language-button` with fixed width

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889e81b66d48330bfcf99749b0fd1fe